### PR TITLE
Dev save all nodes

### DIFF
--- a/src/lib/classes/layoutTree.ts
+++ b/src/lib/classes/layoutTree.ts
@@ -1,5 +1,7 @@
 import type { Database } from '$lib/types/supabase';
 import { supabase } from '$lib/supabaseClient';
+import type Layout from '../../routes/+layout.svelte';
+import type LayoutNode from '$lib/components/layoutNode.svelte';
 
 type LayoutNodeDB = Database['public']['Tables']['layout_nodes']['Row']
 type LayoutNodeDBArray = Array<LayoutNodeDB>
@@ -43,6 +45,11 @@ export class LayoutNodeCls {
         return this
     }
 
+    setContent(content: string): LayoutNodeCls {
+        this._content = content
+        return this
+    }
+
     move(dx: number, dy: number): LayoutNodeCls {
         let [x, y] = this._position
         this.setPosition(x + dx, y + dy)
@@ -63,9 +70,11 @@ export class LayoutNodeCls {
     async saveChanges(): Promise<LayoutNodeCls> {
         this.data.top = this.top
         this.data.left = this.left
+        this.data.content = this.content
         
+        // prefer to send less data
         const { error } = await supabase.from('layout_nodes')
-            .update({top:this.top, left:this.left})
+            .update({top:this.top, left:this.left, content:this.content})
             .eq('id', this.id)
 
         if (error) console.log(error)

--- a/src/lib/classes/layoutTree.ts
+++ b/src/lib/classes/layoutTree.ts
@@ -31,16 +31,18 @@ export class LayoutNodeCls {
     get id(): number { return this.data.id }
     get key(): string { return this.data.key }
 
-    setSize(width: number, height: number) {
-        this._size = [width, height]
-    }
-
-    setPosition(left: number, top: number) {
-        this._position = [Math.round(left), Math.round(top)]
-    }
-
     // the self return pattern is a reminder that the object mutation
     // must use an assignment statement to trigger reactivity
+    setSize(width: number, height: number): LayoutNodeCls {
+        this._size = [width, height]
+        return this
+    }
+
+    setPosition(left: number, top: number): LayoutNodeCls {
+        this._position = [Math.round(left), Math.round(top)]
+        return this
+    }
+
     move(dx: number, dy: number): LayoutNodeCls {
         let [x, y] = this._position
         this.setPosition(x + dx, y + dy)

--- a/src/lib/components/activeNodePanel.svelte
+++ b/src/lib/components/activeNodePanel.svelte
@@ -50,13 +50,25 @@
             { $activeNode?.key || ''}
         </span>
 
-        <input 
-            bind:value={top} type='number' class='text-black'
-            on:focus={startEditing}
-            on:blur={endEditing}
-            on:keyup={onkey}
-        />
-        <span>left: {left}</span>
+        <label for="top-input" class="label flex items-center w-[100%]">
+            <span class="mr-4">Top:</span>
+            <input name="top-input" type='number' class="input variant-form-material"
+                bind:value={top} 
+                on:focus={startEditing}
+                on:blur={endEditing}
+                on:keyup={onkey}
+            />
+        </label>
+
+        <label for="left-input" class="label flex items-center w-[100%]">
+            <span class="mr-4">Left:</span>
+            <input name="left-input" type='number' class="input variant-form-material"
+                bind:value={left} 
+                on:focus={startEditing}
+                on:blur={endEditing}
+                on:keyup={onkey}
+            />
+        </label>
 
         {#if unsaved}
             <div class="px-2 p-1 h4 mt-4 w-[100%] flex justify-around">

--- a/src/lib/components/activeNodePanel.svelte
+++ b/src/lib/components/activeNodePanel.svelte
@@ -8,10 +8,11 @@
     let unsaved: boolean
     $: unsaved = $activeNode?.unsaved || false
 
-    let top: number, left: number, editing: boolean
+    let top: number, left: number, content: string, editing: boolean
     $: if ($activeNode && !editing) {
         top = $activeNode.top
         left = $activeNode.left
+        content = $activeNode.content
     }
 
     const startEditing = () => {
@@ -21,6 +22,7 @@
     const endEditing = () => {
         editing = false
         if ($activeNode) {
+            $activeNode.setContent(content)
             activeNode.set($activeNode.setPosition(left, top))
         }
         $layoutTree.update()
@@ -64,6 +66,16 @@
             <span class="mr-4">Left:</span>
             <input name="left-input" type='number' class="input variant-form-material"
                 bind:value={left} 
+                on:focus={startEditing}
+                on:blur={endEditing}
+                on:keyup={onkey}
+            />
+        </label>
+
+        <label for="content-input" class="label flex flex-col items-start w-[100%]">
+            <span class="mr-4">Content:</span>
+            <input name="content-input" type='text' class="input variant-form-material"
+                bind:value={content} 
                 on:focus={startEditing}
                 on:blur={endEditing}
                 on:keyup={onkey}

--- a/src/lib/components/activeNodePanel.svelte
+++ b/src/lib/components/activeNodePanel.svelte
@@ -1,11 +1,38 @@
 <script lang='ts'>
 	import type { LayoutNodeCls } from "$lib/classes/layoutTree"
+    import { layoutTree } from "$lib/stores/layoutStore"
     import { createEventDispatcher } from "svelte"
     import { activeNode } from "$lib/stores/editor"
     const dispatch = createEventDispatcher()
 
     let unsaved: boolean
     $: unsaved = $activeNode?.unsaved || false
+
+    let top: number, left: number, editing: boolean
+    $: if ($activeNode && !editing) {
+        top = $activeNode.top
+        left = $activeNode.left
+    }
+
+    const startEditing = () => {
+        editing = true
+    }
+
+    const endEditing = () => {
+        editing = false
+        if ($activeNode) {
+            activeNode.set($activeNode.setPosition(left, top))
+        }
+        $layoutTree.update()
+    }
+
+    const onkey = (e: KeyboardEvent) => {
+        if (e.key === 'Enter') endEditing()
+        else {
+            if (!editing) startEditing()
+        }
+    }
+
 </script>
 
 {#if $activeNode}
@@ -23,8 +50,13 @@
             { $activeNode?.key || ''}
         </span>
 
-        <span>top: {$activeNode.top}</span>
-        <span>left: {$activeNode.left}</span>
+        <input 
+            bind:value={top} type='number' class='text-black'
+            on:focus={startEditing}
+            on:blur={endEditing}
+            on:keyup={onkey}
+        />
+        <span>left: {left}</span>
 
         {#if unsaved}
             <div class="px-2 p-1 h4 mt-4 w-[100%] flex justify-around">

--- a/src/lib/components/activeNodePanel.svelte
+++ b/src/lib/components/activeNodePanel.svelte
@@ -1,14 +1,14 @@
 <script lang='ts'>
 	import type { LayoutNodeCls } from "$lib/classes/layoutTree"
     import { createEventDispatcher } from "svelte"
+    import { activeNode } from "$lib/stores/editor"
     const dispatch = createEventDispatcher()
 
-    export let node: LayoutNodeCls | null
     let unsaved: boolean
-    $: unsaved = node?.unsaved || false
+    $: unsaved = $activeNode?.unsaved || false
 </script>
 
-{#if node}
+{#if $activeNode}
     <div id="node-info-panel" 
         class="variant-glass-primary 
             rounded px-4 pt-1 m-4 
@@ -20,11 +20,11 @@
             text-white">
 
         <span class="h3 mb-2">
-            { node?.key || ''}
+            { $activeNode?.key || ''}
         </span>
 
-        <span>top: {node.top}</span>
-        <span>left: {node.left}</span>
+        <span>top: {$activeNode.top}</span>
+        <span>left: {$activeNode.left}</span>
 
         {#if unsaved}
             <div class="px-2 p-1 h4 mt-4 w-[100%] flex justify-around">

--- a/src/lib/components/layoutNode.svelte
+++ b/src/lib/components/layoutNode.svelte
@@ -4,7 +4,6 @@
     import { layoutTree } from '$lib/stores/layoutStore'
     import { stateVariableStore } from '$lib/stores/varStore'
     import { activeNode, scalePercent } from '$lib/stores/editor'
-	import Layout from '../../routes/+layout.svelte';
     
     export let node: LayoutNodeCls
     export let edit: boolean

--- a/src/lib/components/layoutNode.svelte
+++ b/src/lib/components/layoutNode.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
     import type { LayoutNodeCls } from '$lib/classes/layoutTree'
     import type { StateVariableValue } from '$lib/classes/variableMap'
+    import { layoutTree } from '$lib/stores/layoutStore'
     import { stateVariableStore } from '$lib/stores/varStore'
     import { activeNode, scalePercent } from '$lib/stores/editor'
+	import Layout from '../../routes/+layout.svelte';
     
     export let node: LayoutNodeCls
     export let edit: boolean
@@ -35,6 +37,7 @@
         if (moving) {
             node = node.move(e.movementX * moveFactor, e.movementY * moveFactor)
             activeNode.set(node)
+            $layoutTree.update()
         }
 	}	
 

--- a/src/lib/components/scalePanel.svelte
+++ b/src/lib/components/scalePanel.svelte
@@ -1,6 +1,16 @@
 <script lang="ts">
     import { RangeSlider } from "@skeletonlabs/skeleton"
     import { scalePercent } from "$lib/stores/editor"
+
+    function wheel(e: WheelEvent) {
+        e.preventDefault()
+
+        if (e.deltaY > 0) {
+            scalePercent.set(Math.max($scalePercent - 5, 25))
+        } else if (e.deltaY < 0) {
+            scalePercent.set(Math.min($scalePercent + 5, 100))
+        }
+    }
 </script>
 
 <div id="scale-slider-container" 
@@ -18,6 +28,8 @@
         </div>
     </RangeSlider>
 </div>
+
+<svelte:window on:wheel={wheel} />
 
 <style>
     #scale-slider-container {opacity: 0;}

--- a/src/lib/components/unsavedPanel.svelte
+++ b/src/lib/components/unsavedPanel.svelte
@@ -1,0 +1,22 @@
+<script lang='ts'>
+    import { layoutTree } from "$lib/stores/layoutStore";
+    // import type { LayoutNodeCls } from "$lib/classes/layoutTree"
+    // export let nodes: Array<LayoutNodeCls>
+
+</script>
+
+<div id="unsaved-panel" class="variant-glass-primary rounded p-4">
+    <h1 class="h1">UNSAVED</h1>
+    {#each $layoutTree.nodes.filter(n => n.unsaved) as node}
+        <p>{node.key}</p>
+    {/each}
+</div>
+
+<style>
+    #unsaved-panel {
+        position: absolute;
+        z-index: 2;
+        right: 100px;
+        bottom: 100px;
+    }
+</style>

--- a/src/lib/components/unsavedPanel.svelte
+++ b/src/lib/components/unsavedPanel.svelte
@@ -1,16 +1,39 @@
 <script lang='ts'>
-    import { layoutTree } from "$lib/stores/layoutStore";
-    // import type { LayoutNodeCls } from "$lib/classes/layoutTree"
-    // export let nodes: Array<LayoutNodeCls>
+    import type { LayoutNodeCls } from "$lib/classes/layoutTree"
+    import { layoutTree } from "$lib/stores/layoutStore"
+    import { activeNode } from "$lib/stores/editor"
+    import { createEventDispatcher } from "svelte"
+    const dispatch = createEventDispatcher()
 
+    let nodes: Array<LayoutNodeCls>
+    $: nodes = $layoutTree.nodes.filter(n => n.unsaved)
 </script>
 
-<div id="unsaved-panel" class="variant-glass-primary rounded p-4">
-    <h1 class="h1">UNSAVED</h1>
-    {#each $layoutTree.nodes.filter(n => n.unsaved) as node}
-        <p>{node.key}</p>
-    {/each}
-</div>
+{#if nodes.length}
+    <div id="unsaved-panel" 
+        class="variant-glass-primary rounded px-4 pb-2 text-white flex flex-col">
+
+        <h1 class="h3 mb-2">Unsaved Changes:</h1>
+        {#each nodes as node}
+            <button 
+                class="btn btn-sm mb-1 variant-ghost-primary" 
+                on:click={() => activeNode.set(node)}>
+                {node.key}
+            </button>
+        {/each}
+
+        <div class="flex justify-around mt-2">
+            <button on:click={() => dispatch('save_all')}
+                class="btn btn-sm variant-filled-primary">
+                Save All
+            </button>
+            <button on:click={() => dispatch('reset_all')}
+                class="btn btn-sm variant-filled-primary">
+                Reset All
+            </button>
+        </div>
+    </div>
+{/if}
 
 <style>
     #unsaved-panel {

--- a/src/routes/stream/[[edit]]/+page.svelte
+++ b/src/routes/stream/[[edit]]/+page.svelte
@@ -2,11 +2,13 @@
     import { page } from "$app/stores"
     import { layoutTree } from "$lib/stores/layoutStore"
     import { activeNode, scalePercent } from "$lib/stores/editor.js"
+	import type { LayoutNodeCls } from "$lib/classes/layoutTree.js"
 
+    import streamBG from "$lib/images/stream-bg.png"
     import LayoutNode from "$lib/components/layoutNode.svelte"
     import ActiveNodePanel from "$lib/components/activeNodePanel.svelte"
-    import streamBG from "$lib/images/stream-bg.png"
     import ScalePanel from "$lib/components/scalePanel.svelte"
+    import UnsavedPanel from "$lib/components/unsavedPanel.svelte"
 
     export let data
     let edit: boolean
@@ -23,6 +25,10 @@
             activeNode.set(nodeSaved)
         }
         $layoutTree.update()
+    }
+
+    const getUnsaved = (): Array<LayoutNodeCls> => {
+        return $layoutTree.nodes.filter(n => n.unsaved)
     }
 </script>
 
@@ -55,10 +61,11 @@
 {#if edit}
     <ActiveNodePanel 
         on:reset_active={reset}
-        on:save_active={save}
-        node={$activeNode}/>
+        on:save_active={save}/>
         
     <ScalePanel />
+
+    <UnsavedPanel />
 {/if}
 
 <style>


### PR DESCRIPTION
An additional panel was added to the editor view that lists all unsaved nodes, with the ability to click and set each to the active node, as well as save all or reset all changes.

Input fields for positioning and div content were added to the active node panel as well.

Also, mouse wheel scrolling can now be used to affect the zoom.