### PR TITLE
Refactor Active Node store to Active Node ID store

### DIFF
--- a/src/lib/classes/dbProxy.ts
+++ b/src/lib/classes/dbProxy.ts
@@ -68,15 +68,13 @@ export class ProxyDBRow<T extends DatabaseTableName> {
         this.broadcast()
     }
 
-    async saveChangesToDB(table: DatabaseTableName): Promise<ProxyDBRow<T>> {
+    async saveChangesToDB(table: DatabaseTableName) {
         const { error } = await supabase.from(table)
             .update(this.changes).eq('id', this.data.id)
         
         if (error) throw Error(error.message)
 
         this.saveChangesToProxy()
-
-        return this
     }
 
     saveChangesToProxy() {

--- a/src/lib/classes/layoutNodes.ts
+++ b/src/lib/classes/layoutNodes.ts
@@ -33,40 +33,36 @@ export class LayoutNodeProxy extends ProxyDBRow<'layout_nodes'> {
         return [this.left, this.top]
     }
 
-    // the self return pattern is a reminder that the object mutation
-    // must use an assignment statement to trigger reactivity
-    setSize(width: number, height: number): LayoutNodeProxy {
-        return this.update({width, height})
+    setSize(width: number, height: number) {
+        this.update({width, height})
     }
 
-    setPosition(left: number, top: number): LayoutNodeProxy {
-        return this.update({
+    setPosition(left: number, top: number) {
+        this.update({
             left: Math.round(left),
             top: Math.round(top)
         })
     }
 
-    setContent(content: string): LayoutNodeProxy {
-        return this.update({content})
+    setContent(content: string) {
+        this.update({content})
     }
 
-    move(dx: number, dy: number): LayoutNodeProxy {
+    move(dx: number, dy: number) {
         let [x, y] = this.position
-        return this.setPosition(x + dx, y + dy)
+        this.setPosition(x + dx, y + dy)
     }
 
     setCSS(classes: string) {
-        return this.update({classes})
+        this.update({classes})
     }
     
-    resetChanges(): LayoutNodeProxy {
+    resetChanges() {
         super.resetChanges()
-        return this.update({})
     }
 
-    async saveChangesToDB(): Promise<LayoutNodeProxy> {
+    async saveChangesToDB() {
         await super.saveChangesToDB('layout_nodes')
-        return this
     }
 }
 

--- a/src/lib/classes/layoutNodes.ts
+++ b/src/lib/classes/layoutNodes.ts
@@ -87,5 +87,9 @@ export const layoutNodes = {
         return getProxies<'layout_nodes', LayoutNodeRow, LayoutNodeProxy>(
             nodes, set, LayoutNodeProxy
         )
+    },
+
+    getNodeByID: (nodes: LayoutNodeProxy[], id: number|null): LayoutNodeProxy|null => {
+        return nodes.filter(n=>n.id===id)[0] ?? null
     }
 }

--- a/src/lib/components/activeNodePanel.svelte
+++ b/src/lib/components/activeNodePanel.svelte
@@ -4,7 +4,6 @@
 	import { layoutNodes, type LayoutNodeProxy } from "$lib/classes/layoutNodes.js"
     const dispatch = createEventDispatcher()
 
-    // TODO: why can't these lines be combined in this file?
     let activeNode: LayoutNodeProxy | null
     $: activeNode = layoutNodes.getNodeByID($layoutNodes, $activeNodeID)
     

--- a/src/lib/components/activeNodePanel.svelte
+++ b/src/lib/components/activeNodePanel.svelte
@@ -1,17 +1,24 @@
 <script lang='ts'>
     import { createEventDispatcher } from "svelte"
-    import { activeNode } from "$lib/stores/editor"
+    import { activeNodeID } from "$lib/stores/editor"
+	import { LayoutNodeProxy, layoutNodes } from "$lib/classes/layoutNodes";
     const dispatch = createEventDispatcher()
 
+    let activeNode: LayoutNodeProxy | null
+    const getNodeByID = (nodes: LayoutNodeProxy[], id: number|null): LayoutNodeProxy|null => {
+        return nodes.filter(n=>n.id===id)[0] ?? null
+    }
+    $: activeNode = getNodeByID($layoutNodes, $activeNodeID)
+    
     let editing: boolean = false
     let unsaved: boolean
-    $: unsaved = $activeNode?.unsaved || false
+    $: unsaved = activeNode?.unsaved || false
     
     let top: number, left: number, content: string
-    $: if ($activeNode && !editing) {
-        top = $activeNode.top
-        left = $activeNode.left
-        content = $activeNode.content
+    $: if (activeNode && !editing) {
+        top = activeNode.top
+        left = activeNode.left
+        content = activeNode.content
     }
 
     const startEditing = () => {
@@ -20,9 +27,9 @@
 
     const endEditing = () => {
         editing = false
-        if ($activeNode) {
-            $activeNode.setContent(content)
-            activeNode.set($activeNode.setPosition(left, top))
+        if (activeNode) {
+            activeNode.setContent(content)
+            activeNode.setPosition(left, top)
         }
     }
 
@@ -35,7 +42,7 @@
 
 </script>
 
-{#if $activeNode}
+{#if activeNode}
     <div id="node-info-panel" 
         class="variant-glass-primary 
             rounded px-4 pt-1 m-4 
@@ -47,7 +54,7 @@
             text-white">
 
         <span class="h3 mb-2">
-            { $activeNode?.key || ''}
+            { activeNode.key }
         </span>
 
         <label for="top-input" class="label flex items-center w-[100%]">

--- a/src/lib/components/activeNodePanel.svelte
+++ b/src/lib/components/activeNodePanel.svelte
@@ -1,14 +1,12 @@
 <script lang='ts'>
     import { createEventDispatcher } from "svelte"
     import { activeNodeID } from "$lib/stores/editor"
-	import { LayoutNodeProxy, layoutNodes } from "$lib/classes/layoutNodes";
+	import { layoutNodes, type LayoutNodeProxy } from "$lib/classes/layoutNodes.js"
     const dispatch = createEventDispatcher()
 
+    // TODO: why can't these lines be combined in this file?
     let activeNode: LayoutNodeProxy | null
-    const getNodeByID = (nodes: LayoutNodeProxy[], id: number|null): LayoutNodeProxy|null => {
-        return nodes.filter(n=>n.id===id)[0] ?? null
-    }
-    $: activeNode = getNodeByID($layoutNodes, $activeNodeID)
+    $: activeNode = layoutNodes.getNodeByID($layoutNodes, $activeNodeID)
     
     let editing: boolean = false
     let unsaved: boolean

--- a/src/lib/components/layoutNode.svelte
+++ b/src/lib/components/layoutNode.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type { LayoutNodeProxy } from '$lib/classes/layoutNodes'
     import { stateVariables } from '$lib/classes/stateVariables'
-    import { activeNode, scalePercent } from '$lib/stores/editor'
+    import { activeNodeID, scalePercent } from '$lib/stores/editor'
     
     export let node: LayoutNodeProxy
     export let edit: boolean
@@ -20,7 +20,7 @@
     function start() {
         if (edit) {
             moving = true;
-            activeNode.set(node)
+            activeNodeID.set(node.id)
         }
 	}
 	
@@ -31,7 +31,7 @@
 	function move(e: MouseEvent) {
         if (moving) {
             node = node.move(e.movementX * moveFactor, e.movementY * moveFactor)
-            activeNode.set(node)
+            // activeNode.set(node)
         }
 	}	
 
@@ -53,7 +53,7 @@
         select-none
         cursor-pointer
         {edit ? 'layout-node-edit' : ''}
-        {$activeNode?.id === node.id ? 'layout-node-active' : ''}
+        {$activeNodeID === node.id ? 'layout-node-active' : ''}
         layout-node"
 >
     <span class="layout-node-content">

--- a/src/lib/components/unsavedPanel.svelte
+++ b/src/lib/components/unsavedPanel.svelte
@@ -1,6 +1,6 @@
 <script lang='ts'>
     import { layoutNodes, type LayoutNodeProxy } from "$lib/classes/layoutNodes"
-    import { activeNode } from "$lib/stores/editor"
+    import { activeNodeID } from "$lib/stores/editor"
     import { createEventDispatcher } from "svelte"
     const dispatch = createEventDispatcher()
 
@@ -16,7 +16,7 @@
         {#each nodes as node}
             <button 
                 class="btn btn-sm mb-1 variant-ghost-primary" 
-                on:click={() => activeNode.set(node)}>
+                on:click={() => activeNodeID.set(node)}>
                 {node.key}
             </button>
         {/each}

--- a/src/lib/components/unsavedPanel.svelte
+++ b/src/lib/components/unsavedPanel.svelte
@@ -16,7 +16,7 @@
         {#each nodes as node}
             <button 
                 class="btn btn-sm mb-1 variant-ghost-primary" 
-                on:click={() => activeNodeID.set(node)}>
+                on:click={() => activeNodeID.set(node.id)}>
                 {node.key}
             </button>
         {/each}

--- a/src/lib/stores/editor.ts
+++ b/src/lib/stores/editor.ts
@@ -1,10 +1,11 @@
 import { writable, type Writable } from "svelte/store"
-import type { LayoutNodeProxy } from "$lib/classes/layoutNodes"
+// import type { LayoutNodeProxy } from "$lib/classes/layoutNodes"
 import { localStorageStore } from '@skeletonlabs/skeleton'
 import { get } from "svelte/store"
 
 
-export const activeNode = writable<LayoutNodeProxy | null>()
+// export const activeNode = writable<LayoutNodeProxy | null>()
+export const activeNodeID = writable<number|null>(null)
 
 export const scalePercent: Writable<number> = localStorageStore('scalePercent', 100)
 

--- a/src/routes/stream/[layout]/[[edit]]/+layout.svelte
+++ b/src/routes/stream/[layout]/[[edit]]/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { layoutNodes, type LayoutNodeUpdate } from '$lib/classes/layoutNodes.js'
     import { stateVariables, type StateVariableUpdate } from '$lib/classes/stateVariables.js'
-    import { activeNode } from '$lib/stores/editor'
+    import { activeNodeID } from '$lib/stores/editor'
     import { supabase } from '$lib/supabaseClient.js'
 	import { wheel } from '$lib/stores/editor'
     export let data
@@ -30,7 +30,7 @@
 {#if data.edit}
     <div id='faux-bg'/>
     <!-- svelte-ignore a11y-no-static-element-interactions -->
-    <div id='scale-bg' on:wheel={wheel} on:mousedown={() => activeNode.set(null)}/>
+    <div id='scale-bg' on:wheel={wheel} on:mousedown={() => activeNodeID.set(null)}/>
 {/if}
 
 <slot />

--- a/src/routes/stream/[layout]/[[edit]]/+page.svelte
+++ b/src/routes/stream/[layout]/[[edit]]/+page.svelte
@@ -14,7 +14,8 @@
     let edit: boolean
     $: edit = data.edit
 
-    let activeNode: LayoutNodeProxy | null = layoutNodes.getNodeByID($layoutNodes, $activeNodeID)
+    let activeNode: LayoutNodeProxy | null 
+    $: activeNode = layoutNodes.getNodeByID($layoutNodes, $activeNodeID)
 
 
     const unselectNode = () => {
@@ -22,6 +23,7 @@
     }
     
     const reset = (node: LayoutNodeProxy|null) => {
+        debugger
         if (!node) return
 
         node.resetChanges()

--- a/src/routes/stream/[layout]/[[edit]]/+page.svelte
+++ b/src/routes/stream/[layout]/[[edit]]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang='ts'>
     import { page } from "$app/stores"
-    import { activeNode, scalePercent } from "$lib/stores/editor.js"
+    import { activeNodeID, scalePercent } from "$lib/stores/editor.js"
     import { layoutNodes, type LayoutNodeProxy } from "$lib/classes/layoutNodes.js"
 
     import streamBG from "$lib/images/stream-bg.png"
@@ -14,22 +14,29 @@
     let edit: boolean
     $: edit = data.edit
 
+    let activeNode: LayoutNodeProxy | null
+    const getNodeByID = (nodes: LayoutNodeProxy[], id: number|null): LayoutNodeProxy|null => {
+        return nodes.filter(n=>n.id===id)[0] ?? null
+    }
+    $: activeNode = getNodeByID($layoutNodes, $activeNodeID)
+
+
     const unselectNode = () => {
-        if (edit) activeNode.set(null)
+        if (edit) activeNodeID.set(null)
     }
     
     const reset = (node: LayoutNodeProxy|null) => {
         if (!node) return
 
-        const nodeReset = node.resetChanges()
-        if ($activeNode?.id === node.id) activeNode.set(nodeReset)
+        node.resetChanges()
+        // if ($activeNodeID === node.id) activeNode.set(nodeReset)
     }
 
     const save = async (node: LayoutNodeProxy|null) => {
         if (!node) return
 
-        const nodeSaved = await node.saveChangesToDB()
-        if ($activeNode?.id === node.id) activeNode.set(nodeSaved)
+        await node.saveChangesToDB()
+        // if ($activeNode?.id === node.id) activeNode.set(node.id)
     }
 
     let unsavedNodes: LayoutNodeProxy[]
@@ -69,8 +76,8 @@
 <!-- Beginning of actual edit UI elements -->
 {#if edit}
     <ActiveNodePanel 
-        on:reset_active={() => reset($activeNode)}
-        on:save_active={() => save($activeNode)}/>
+        on:reset_active={() => reset(activeNode)}
+        on:save_active={() => save(activeNode)}/>
         
     <ScalePanel />
 

--- a/src/routes/stream/[layout]/[[edit]]/+page.svelte
+++ b/src/routes/stream/[layout]/[[edit]]/+page.svelte
@@ -14,11 +14,7 @@
     let edit: boolean
     $: edit = data.edit
 
-    let activeNode: LayoutNodeProxy | null
-    const getNodeByID = (nodes: LayoutNodeProxy[], id: number|null): LayoutNodeProxy|null => {
-        return nodes.filter(n=>n.id===id)[0] ?? null
-    }
-    $: activeNode = getNodeByID($layoutNodes, $activeNodeID)
+    let activeNode: LayoutNodeProxy | null = layoutNodes.getNodeByID($layoutNodes, $activeNodeID)
 
 
     const unselectNode = () => {
@@ -29,14 +25,12 @@
         if (!node) return
 
         node.resetChanges()
-        // if ($activeNodeID === node.id) activeNode.set(nodeReset)
     }
 
     const save = async (node: LayoutNodeProxy|null) => {
         if (!node) return
 
         await node.saveChangesToDB()
-        // if ($activeNode?.id === node.id) activeNode.set(node.id)
     }
 
     let unsavedNodes: LayoutNodeProxy[]


### PR DESCRIPTION
This refactor makes consumers of the activeNode store now responsible for subscribing to an ID value and using the layoutNodes store to filter down to the active node proxy object.

This allows for the removal of superfluous self returns in the layout node proxy class and manual reassignments within the business logic of the layout editor itself.