### PR TITLE
Dev/new node modal

### DIFF
--- a/src/lib/components/layoutNode.svelte
+++ b/src/lib/components/layoutNode.svelte
@@ -20,9 +20,10 @@
 
     // handle var values / interpolation
     const varValue = stateVariables.getVarStore(node.variable_id)
-    const interpVars = (key: string) => stateVariables.getVarByKey($stateVariables, key)
     let content: string
-    $: content = node.interpolate(interpVars)
+    $: content = node.interpolate(
+        (key: string) => stateVariables.getVarByKey($stateVariables, key)
+    )
 
     // set up positional CSS
     let posCSS: string, wCSS: string, hCSS: string, 

--- a/src/lib/components/layoutNode.svelte
+++ b/src/lib/components/layoutNode.svelte
@@ -11,8 +11,10 @@
     export let edit: boolean
     export let child: boolean = false
     export let depth: number = 0
-    let imgURI: string
-    $: imgURI = `${$page.data.imageBaseUrl}/${node.user_id}/${node.image}`
+
+    let imgURL: string 
+    $: imgURL = `${$page.data.imageBaseUrl}/${node.user_id}/${node.image}`
+
     let display: StateVarValue = true
     $: if (node.boolean_id) {
         display = stateVariables.getVarByID($stateVariables, node.boolean_id)
@@ -24,16 +26,6 @@
     $: content = node.interpolate(
         (key: string) => stateVariables.getVarByKey($stateVariables, key)
     )
-
-    // set up positional CSS
-    let posCSS: string, wCSS: string, hCSS: string, 
-        inlineCSS: string, imgCSS: string, hiddenCSS: string
-    $: posCSS = `top: ${node.top}px; left: ${node.left}px;`
-    $: wCSS = node.width ? `width: ${node.width}px;` : ''
-    $: hCSS = node.height ? `height: ${node.height}px;` : ''
-    $: imgCSS = node.image ? `background-image: url(${imgURI});` : '' 
-    $: hiddenCSS = display ? '' : 'display: none;'
-    $: inlineCSS = `${posCSS}${wCSS}${hCSS}${imgCSS}${hiddenCSS}`
     
     // handle movement / positioning
     let moving: boolean = false
@@ -75,9 +67,14 @@
     on:contextmenu|stopPropagation|preventDefault
     on:mousedown|preventDefault|stopPropagation={isClicked} 
     id="layoutNode-{node.key}"
-    style={inlineCSS}
+
+    style:top={`${node.top}px`}
+    style:left={`${node.left}px`}
+    style:width={node.width ? `${node.width}px` : null}
+    style:height={node.height ? `${node.height}px` : null}
+    style:background-image={node.image ? `url(${imgURL})` : null}
+
     class="{node.classes} layout-node
-        min-w-content min-h-content
         select-none cursor-pointer"
     class:absolute={!child}
     class:layout-node-active={$activeNodeID === node.id}

--- a/src/lib/components/layoutNode.svelte
+++ b/src/lib/components/layoutNode.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type { LayoutNodeProxy } from '$lib/classes/layoutNodes'
     import { stateVariables } from '$lib/classes/stateVariables'
-    import { activeNodeID, scalePercent } from '$lib/stores/editor'
+    import { activeNodeID, ctxMenu, scalePercent, type CtxMenu } from '$lib/stores/editor'
     import { createEventDispatcher } from 'svelte'
     import { page } from '$app/stores'
 	import type { StateVarValue } from '$lib/classes/dbProxy';
@@ -56,6 +56,14 @@
         }
 	}
 
+    const getMenu = (n: LayoutNodeProxy): CtxMenu => ([
+        {key: `Save ${n.key}`, 
+            disabled: !n.unsaved, 
+            action: () => n.saveChangesToDB()},
+        {key: `Reset ${n.key}`, 
+            disabled: !n.unsaved, 
+            action: () => n.resetChanges()},
+    ])
 </script>
 
 <svelte:window on:mouseup={stopMovement} on:mousemove={move}  />
@@ -64,7 +72,7 @@
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
 <!-- svelte-ignore a11y-interactive-supports-focus -->
 <div
-    on:contextmenu|stopPropagation|preventDefault
+    on:contextmenu|stopPropagation|preventDefault={e => ctxMenu.open(e, getMenu(node))}
     on:mousedown|preventDefault|stopPropagation={isClicked} 
     id="layoutNode-{node.key}"
 

--- a/src/lib/components/layoutNode.svelte
+++ b/src/lib/components/layoutNode.svelte
@@ -13,7 +13,7 @@
     export let depth: number = 0
     let imgURI: string
     $: imgURI = `${$page.data.imageBaseUrl}/${node.user_id}/${node.image}`
-    let display: StateVarValue
+    let display: StateVarValue = true
     $: if (node.boolean_id) {
         display = stateVariables.getVarByID($stateVariables, node.boolean_id)
     }

--- a/src/lib/components/menu/contextMenu.svelte
+++ b/src/lib/components/menu/contextMenu.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { ctxMenu, activeNodeID, type CtxMenuItem } from "$lib/stores/editor"
+    import { ctxMenu, activeNodeID, type CtxMenuItem, type CtxMenu } from "$lib/stores/editor"
     import { LayoutNodeProxy, layoutNodes } from "$lib/classes/layoutNodes"
     
     let activeNode: LayoutNodeProxy | null 
@@ -13,9 +13,9 @@
         if (item.action) item.action()
     }
 
-    let options: [string, CtxMenuItem][]
+    let options: CtxMenu
     $: {
-        options = Object.entries($ctxMenu.menu ?? [])
+        options = $ctxMenu.menu ?? []
     }
 </script>
 
@@ -25,14 +25,14 @@
     style={`top: ${$ctxMenu.top ?? 0}px; left: ${$ctxMenu.left ?? 0}px`}
     >
     
-    {#each options as [key, item]}
+    {#each options as option}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <!-- svelte-ignore a11y-no-static-element-interactions -->
         <div 
             class={`hover:bg-primary-600 p-2 cursor-pointer`}
-            class:disabled={item.disabled}
-            on:click={(e) => handleClick(e, item)}>
-                {key}
+            class:disabled={option.disabled || !option.action}
+            on:click={(e) => handleClick(e, option)}>
+                {option.key}
         </div>
     {/each}
 

--- a/src/lib/stores/editor.ts
+++ b/src/lib/stores/editor.ts
@@ -23,10 +23,11 @@ type CtxMenuState = {
     menu?: CtxMenu
 }
 export type CtxMenuItem = {
+    key: string
     disabled?: boolean
     action?: () => void
 }
-export type CtxMenu = Record<string, CtxMenuItem>
+export type CtxMenu = CtxMenuItem[]
 
 const {set, update, subscribe} = writable<CtxMenuState>({hidden: true})
 export const ctxMenu = {

--- a/src/routes/stream/[layout]/[[edit]]/+layout.svelte
+++ b/src/routes/stream/[layout]/[[edit]]/+layout.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
     import { layoutNodes, type LayoutNodeUpdate } from '$lib/classes/layoutNodes.js'
     import { stateVariables, type StateVariableUpdate } from '$lib/classes/stateVariables.js'
-    import { activeNodeID, ctxMenu } from '$lib/stores/editor'
+    import { activeNodeID } from '$lib/stores/editor'
     import { supabase } from '$lib/supabaseClient.js'
 	import { wheel } from '$lib/stores/editor'
 
-    import ContextMenu from '$lib/components/menu/contextMenu.svelte'
     export let data
 
     layoutNodes.set(layoutNodes.getNodes(data.nodes))
@@ -28,15 +27,7 @@
             }
         }).subscribe()
 
-    const menu = {
-        "Save All": {disabled: true},
-        "Reset All": {disabled: true},
-        "Say hello": {action: () => alert("hello!")}
-    }
 </script>
-
-<svelte:window on:click={ctxMenu.close}/>
-<ContextMenu />
 
 
 {#if data.edit}
@@ -46,7 +37,7 @@
 
     <!-- svelte-ignore a11y-no-static-element-interactions -->
     <div id='scale-bg'
-        on:contextmenu|preventDefault={(e) => ctxMenu.open(e, menu)}
+        on:contextmenu|preventDefault
         on:wheel|preventDefault={wheel} 
         on:mousedown={() => activeNodeID.set(null)}/>
 {/if}

--- a/src/routes/stream/[layout]/[[edit]]/+layout.svelte
+++ b/src/routes/stream/[layout]/[[edit]]/+layout.svelte
@@ -11,21 +11,19 @@
 
     stateVariables.set(stateVariables.getVars(data.stateVariables))
 
-    supabase.channel('state_vars_realtime').on('postgres_changes', 
-        {event: '*', schema: 'public', table: 'state_variables'},
+    supabase.channel('changes').on('postgres_changes',
+        {event: '*', schema: 'public'},
         payload => {
             if (payload.new) {
-                stateVariables.updateVar($stateVariables, payload.new as StateVariableUpdate)
+                if (payload.table === 'layout_nodes') {
+                    layoutNodes.updateNode($layoutNodes, payload.new as LayoutNodeUpdate)
+                }
+                if (payload.table === 'state_variables') {
+                    stateVariables.updateVar($stateVariables, payload.new as StateVariableUpdate)
+                }
             }
-        }).subscribe()
-    
-    supabase.channel('layout_nodes_realtime').on('postgres_changes', 
-        {event: '*', schema: 'public', table: 'layout_nodes'},
-        payload => {
-            if (payload.new) {
-                layoutNodes.updateNode($layoutNodes, payload.new as LayoutNodeUpdate)
-            }
-        }).subscribe()
+        }
+    ).subscribe()
 
 </script>
 

--- a/src/routes/stream/[layout]/[[edit]]/+page.svelte
+++ b/src/routes/stream/[layout]/[[edit]]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang='ts'>
     import { page } from "$app/stores"
-    import { activeNodeID, scalePercent } from "$lib/stores/editor.js"
+    import { activeNodeID, ctxMenu, scalePercent } from "$lib/stores/editor.js"
     import { layoutNodes, type LayoutNodeProxy } from "$lib/classes/layoutNodes.js"
 
     import streamBG from "$lib/images/stream-bg.png"
@@ -8,6 +8,8 @@
     import EditNodePanel from "$lib/components/edit/editNodePanel.svelte"
     import ScalePanel from "$lib/components/scalePanel.svelte"
     import UnsavedPanel from "$lib/components/unsavedPanel.svelte"
+    import ContextMenu from '$lib/components/menu/contextMenu.svelte'
+
     import { wheel } from "$lib/stores/editor.js"
 
     export let data
@@ -21,15 +23,24 @@
         if (edit) activeNodeID.set(null)
     }
 
+    const menu = {
+        "Save All": {disabled: true},
+        "Reset All": {disabled: true},
+        "Say hello": {action: () => alert("hello!")}
+    }
 </script>
 
+<svelte:window 
+    on:click={ctxMenu.close} 
+    on:contextmenu|preventDefault={(e) => ctxMenu.open(e, menu)}/>
+<ContextMenu />
 
 <!-- 'Edit Layout' panel for switching to edit mode -->
 {#if !edit}
     <div id="open-editor-panel">
         <a 
             href={`${$page.url.pathname}/edit`} 
-            class="bg-primary-500 p-4 h5 text-white m-4">
+            class="bg-primary-500 p-4 h5 text-white m-4 rounded">
             Edit Layout
         </a>
     </div>

--- a/src/routes/stream/[layout]/[[edit]]/+page.svelte
+++ b/src/routes/stream/[layout]/[[edit]]/+page.svelte
@@ -26,12 +26,16 @@
         if (edit) activeNodeID.set(null)
     }
 
-    const getMenu = (): CtxMenu => ({
-        "Save All":     {disabled: !unsavedNodes.length, 
-                        action: () => unsavedNodes.forEach(n => n.saveChangesToDB())},
-        "Reset All":    {disabled: !unsavedNodes.length, 
-                        action: () => unsavedNodes.forEach(n => n.resetChanges())},
-    })
+    const getMenu = (): CtxMenu => ([
+        {key: "Save All",     
+            disabled: !unsavedNodes.length, 
+            action: () => unsavedNodes.forEach(n => n.saveChangesToDB())
+        },
+        {key: "Reset All",    
+            disabled: !unsavedNodes.length, 
+            action: () => unsavedNodes.forEach(n => n.resetChanges())
+        },
+    ])
 </script>
 
 <svelte:window 

--- a/src/routes/stream/[layout]/[[edit]]/+page.svelte
+++ b/src/routes/stream/[layout]/[[edit]]/+page.svelte
@@ -46,7 +46,8 @@
         <!-- svelte-ignore a11y-no-static-element-interactions -->
         <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
         <img src={streamBG} alt="stream bg" 
-            on:mousedown|preventDefault={() => unselectNode()} 
+            on:mousedown|preventDefault={() => unselectNode()}
+            on:contextmenu|preventDefault
             />
     {/if}
 


### PR DESCRIPTION
The Layout Node component now has functional save/reset options in the context menu. 
**INTERNAL/REFACTOR**: Style directives now preferred for better clarity

The Context Menu state store in `stores/editor.js` changes the type definition for the menu to be an array of menu items where each item has a `key` property so that the context menu item can use proper string interpolation.

**MORE REFACTORING**:
* **stream/[layout]/[[edit]]/+layout.svelte** no longer defines the root level context menu (this has been moved to `+page.svelte`) and the supabase realtime subscriptions have been consolidated to a single method call that takes up less space.