### PR TITLE
Dev/delete nodes

### DIFF
--- a/src/lib/classes/dbProxy.ts
+++ b/src/lib/classes/dbProxy.ts
@@ -103,6 +103,15 @@ export class ProxyDBRow<T extends DatabaseTableName> {
         }
     }
 
+    async deleteFromDB(table: DatabaseTableName) {
+        if (!this.client) {
+            const { error } = await supabase.from(table)
+                .delete().eq("id", this.data.id).select().single()
+            
+            if (error) throw Error(error.message)
+        }
+    }
+
     saveChangesToProxy() {
         Object.assign(this.data, this.changes)
         this.changes = {}

--- a/src/lib/classes/layoutNodes.ts
+++ b/src/lib/classes/layoutNodes.ts
@@ -85,6 +85,10 @@ export class LayoutNodeProxy extends ProxyDBRow<'layout_nodes'> {
         })
     }
 
+    removeChild(node: LayoutNodeProxy) {
+        this.children = this.children.filter(n => n.id !== node.id)
+    }
+
     static getAsInsert(key: string, user_id: string, layout_id: number, broadcast: Function): LayoutNodeProxy {
         const data: DatabaseRow<'layout_nodes'> = {
             boolean_key: null,
@@ -150,5 +154,9 @@ export const layoutNodes = {
     delete: (nodes: LayoutNodeProxy[], node: LayoutNodeProxy) => {
         set(nodes.filter(n => n.id !== node.id))
         node.deleteFromDB()
+        if (node.parent_node_id) {
+            const parent = nodes.filter(n => n.id === node.parent_node_id)[0]
+            parent.removeChild(node)
+        }
     }
 }

--- a/src/lib/classes/layoutNodes.ts
+++ b/src/lib/classes/layoutNodes.ts
@@ -59,6 +59,10 @@ export class LayoutNodeProxy extends ProxyDBRow<'layout_nodes'> {
         await super.saveChangesToDB('layout_nodes')
     }
 
+    async deleteFromDB() {
+        await super.deleteFromDB('layout_nodes')
+    }
+
     interpolate(getVarByKey: (key: string) => StateVarValue): string {
         return this.content.replace(/{([^}]+)}/g, (match: string, key: string) => {
             const replacement = getVarByKey(key)
@@ -112,7 +116,7 @@ const {subscribe, set, update} = writable<LayoutNodeProxy[]>([])
 export const layoutNodes = {
     subscribe, set, update,
 
-    updateNode: (nodes: LayoutNodeProxy[], update: LayoutNodeUpdate) => {
+    updateData: (nodes: LayoutNodeProxy[], update: LayoutNodeUpdate) => {
         updateProxy<'layout_nodes', LayoutNodeProxy>(
             nodes, update, 'layout_nodes'
         )
@@ -137,10 +141,14 @@ export const layoutNodes = {
         return nodes.filter(n=>n.id===id)[0] ?? null
     },
 
-    addNode: (nodes: LayoutNodeProxy[], key: string, user_id: string, layout_id: number) => {
+    add: (nodes: LayoutNodeProxy[], key: string, user_id: string, layout_id: number) => {
         const node = LayoutNodeProxy.getAsInsert(key, user_id, layout_id, () => set(nodes))
-        node.broadcast
         nodes.push(node)
         set(nodes)
+    },
+
+    delete: (nodes: LayoutNodeProxy[], node: LayoutNodeProxy) => {
+        set(nodes.filter(n => n.id !== node.id))
+        node.deleteFromDB()
     }
 }

--- a/src/lib/classes/stateVariables.ts
+++ b/src/lib/classes/stateVariables.ts
@@ -6,10 +6,6 @@ export type StateVariableRow = DatabaseRow<'state_variables'>
 export type StateVariableUpdate = DatabaseUpdate<'state_variables'>
 
 export class StateVariableProxy extends ProxyDBRow<'state_variables'> {
-    constructor(data: StateVariableRow, broadcast: Function | null = null) {
-        super(data, broadcast)
-    }
-
     get value(): StateVarValue {
         const stringValue = this.getColumn('value')
 
@@ -37,6 +33,14 @@ export class StateVariableProxy extends ProxyDBRow<'state_variables'> {
 
     async saveChangesToDB() {
         await super.saveChangesToDB('state_variables')
+    }
+
+    async deleteFromDB() {
+        await super.deleteFromDB('state_variables')
+    }
+
+    static getAsInsert(key: string, user_id: string, value: string, broadcast: Function) {
+        return new StateVariableProxy()
     }
 }
     
@@ -67,7 +71,7 @@ export const stateVariables = {
     set: varStore.set, 
     update: varStore.update,
 
-    updateVar: (vars: StateVariableProxy[], update: StateVariableUpdate) => {
+    updateData: (vars: StateVariableProxy[], update: StateVariableUpdate) => {
         updateProxy<'state_variables', StateVariableProxy>(
             vars, update, 'state_variables'
         )
@@ -79,5 +83,15 @@ export const stateVariables = {
         )
     },
 
-    getVarByID, getVarByKey, getVarStore
+    getVarByID, getVarByKey, getVarStore,
+
+    add: (vars: StateVariableProxy[], key: string, user_id: string, value: string) => {
+        const stateVar = StateVariableProxy.getAsInsert(key, user_id, value, () => varStore.set(vars))
+        vars.push(stateVar)
+        varStore.set(vars)
+    },
+
+    delete: (vars: StateVariableProxy[], id: number) => {
+        varStore.set(vars.filter(n => n.id !== id))
+    }
 }

--- a/src/lib/components/layoutNode.svelte
+++ b/src/lib/components/layoutNode.svelte
@@ -124,6 +124,7 @@
             child={true} 
             depth={depth + 1}
             on:dragParent={startMovement}
+            on:deleteNode
         />
     {/each}
 </div>

--- a/src/lib/components/layoutNode.svelte
+++ b/src/lib/components/layoutNode.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
+    import type { StateVarValue } from '$lib/classes/dbProxy';
     import type { LayoutNodeProxy } from '$lib/classes/layoutNodes'
     import { stateVariables } from '$lib/classes/stateVariables'
     import { activeNodeID, ctxMenu, scalePercent, type CtxMenu, type CtxMenuItem } from '$lib/stores/editor'
-    import { createEventDispatcher } from 'svelte'
     import { page } from '$app/stores'
-	import type { StateVarValue } from '$lib/classes/dbProxy';
+    
+    import { createEventDispatcher } from 'svelte'
     const dispatch = createEventDispatcher()
     
     export let node: LayoutNodeProxy
@@ -72,6 +73,11 @@
                     action: () => activeNodeID.set(node.parent_node_id)
                 })
         }
+
+        menu.push(
+            {key: ""},
+            {key: `Delete ${n.key}`, action: () => dispatch('deleteNode', node)}
+        )
 
         return menu
     }

--- a/src/lib/components/layoutNode.svelte
+++ b/src/lib/components/layoutNode.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type { LayoutNodeProxy } from '$lib/classes/layoutNodes'
     import { stateVariables } from '$lib/classes/stateVariables'
-    import { activeNodeID, ctxMenu, scalePercent, type CtxMenu } from '$lib/stores/editor'
+    import { activeNodeID, ctxMenu, scalePercent, type CtxMenu, type CtxMenuItem } from '$lib/stores/editor'
     import { createEventDispatcher } from 'svelte'
     import { page } from '$app/stores'
 	import type { StateVarValue } from '$lib/classes/dbProxy';
@@ -56,14 +56,25 @@
         }
 	}
 
-    const getMenu = (n: LayoutNodeProxy): CtxMenu => ([
-        {key: `Save ${n.key}`, 
-            disabled: !n.unsaved, 
-            action: () => n.saveChangesToDB()},
-        {key: `Reset ${n.key}`, 
-            disabled: !n.unsaved, 
-            action: () => n.resetChanges()},
-    ])
+    const getMenu = (n: LayoutNodeProxy): CtxMenu => {
+        const menu: CtxMenuItem[] = [
+            {key: `Save ${n.key}`, 
+                disabled: !n.unsaved, 
+                action: () => n.saveChangesToDB()},
+            {key: `Reset ${n.key}`, 
+                disabled: !n.unsaved, 
+                action: () => n.resetChanges()}
+        ]
+
+        if (node.parent_node_id) {
+            menu.push(
+                {key: 'Select Parent',
+                    action: () => activeNodeID.set(node.parent_node_id)
+                })
+        }
+
+        return menu
+    }
 </script>
 
 <svelte:window on:mouseup={stopMovement} on:mousemove={move}  />

--- a/src/routes/stream/[layout]/[[edit]]/+layout.svelte
+++ b/src/routes/stream/[layout]/[[edit]]/+layout.svelte
@@ -14,12 +14,13 @@
     supabase.channel('changes').on('postgres_changes',
         {event: '*', schema: 'public'},
         payload => {
+            if (payload.eventType === 'DELETE') return
             if (payload.new) {
                 if (payload.table === 'layout_nodes') {
-                    layoutNodes.updateNode($layoutNodes, payload.new as LayoutNodeUpdate)
+                    layoutNodes.updateData($layoutNodes, payload.new as LayoutNodeUpdate)
                 }
                 if (payload.table === 'state_variables') {
-                    stateVariables.updateVar($stateVariables, payload.new as StateVariableUpdate)
+                    stateVariables.updateData($stateVariables, payload.new as StateVariableUpdate)
                 }
             }
         }

--- a/src/routes/stream/[layout]/[[edit]]/+page.svelte
+++ b/src/routes/stream/[layout]/[[edit]]/+page.svelte
@@ -19,7 +19,7 @@
     let edit: boolean
     $: edit = data.edit
 
-    let activeNode: LayoutNodeProxy | null 
+    let activeNode: LayoutNodeProxy|null
     $: activeNode = layoutNodes.getNodeByID($layoutNodes, $activeNodeID)
     let rootNodes: LayoutNodeProxy[], unsavedNodes: LayoutNodeProxy[]
     $: rootNodes = $layoutNodes.filter(n => !n.parent_node_id)
@@ -29,11 +29,34 @@
         if (edit) activeNodeID.set(null)
     }
 
-    const addNode = (key: string|false) => {
-        if (!key) return
-        if (!$userMeta.uid) throw Error("No User ID found in current userMeta")
-        layoutNodes.addNode(
-            $layoutNodes, key, $userMeta.uid, $page.data.layoutData.id)
+    const addNode = () => {
+        modalStore.trigger({
+            type: 'prompt',
+            title: 'Enter Name',
+            body: 'Provide a unique key to identify this node by',
+            value: 'new_node',
+            valueAttr: { type: 'text', minlength: 1, required: true },
+
+            response: (r: string|false) => {
+                if (r === false) return
+                if (!$userMeta.uid) throw Error("No User ID found in current userMeta")
+
+                layoutNodes.add($layoutNodes, r, $userMeta.uid, $page.data.layoutData.id)
+            }
+        })
+    }
+
+    const deleteNode = (e: CustomEvent) => {
+        const nodeToDelete = e.detail as LayoutNodeProxy
+        modalStore.trigger({
+            type: 'confirm',
+            title: `Delete ${nodeToDelete.key}?`,
+            body: 'Confirm you want to delete this node. This is not reversible!',
+            response: (r: boolean) => {
+                if (!r) return
+                else layoutNodes.delete($layoutNodes, nodeToDelete)
+            }
+        })
     }
 
     const getMenu = (): CtxMenu => ([
@@ -46,14 +69,7 @@
             action: () => unsavedNodes.forEach(n => n.resetChanges())
         },
         {key: "Add New Node",
-            action: () => modalStore.trigger({
-                type: 'prompt',
-                title: 'Enter Name',
-                body: 'Provide a unique key to identify this node by',
-                value: 'new_node',
-                valueAttr: { type: 'text', minlength: 1, required: true },
-                response: (r: string|false) => addNode(r),
-            })
+            action: () => addNode()
         }
     ])
 
@@ -93,7 +109,7 @@
 
     <!-- Beginning of layout node elements -->
     {#each rootNodes as node}
-        <LayoutNode {node} {edit}/>
+        <LayoutNode {node} {edit} on:deleteNode={(e) => deleteNode(e)}/>
     {/each}
 </div>
 

--- a/src/routes/stream/[layout]/[[edit]]/+page.svelte
+++ b/src/routes/stream/[layout]/[[edit]]/+page.svelte
@@ -135,6 +135,6 @@
     }
 
     #active-node-panel {
-        @apply absolute top-0 right-0
+        @apply absolute top-0 right-0 md:mr-20 sm:mr-2
     }
 </style>

--- a/src/routes/vars/+layout.svelte
+++ b/src/routes/vars/+layout.svelte
@@ -11,7 +11,7 @@
         {event: '*', schema: 'public', table: 'state_variables'},
         payload => {
             if (payload.new) {
-                stateVariables.updateVar($stateVariables, payload.new as StateVariableUpdate)
+                stateVariables.updateData($stateVariables, payload.new as StateVariableUpdate)
             }
         }).subscribe()
 </script>


### PR DESCRIPTION
* **dbProxy.ts:** Proxy objects now have a `deleteFromDB` method.
*  **layoutNodes.ts/stateVariables.ts:** The proxy subclasses both export a `add` and `delete` methods in their respective store-like objects. The Layout Nodes proxy class has extra logic for removing references to child nodes from parents when the child node is deleted.
* **layoutNode.svelte:** Context menu now includes a "delete node" action that dispatches an event to the containing +page component.
* **routes/stream/[layout]/[[edit]]/+page.svelte:** Calls to `modalStore.trigger()` moved into top level function definitions and out of the context menu item definitions. The `deleteNode` function was added to support deleting nodes.


**FUTURE:** 
* **stateVariables.ts:** needs to fully implement the `getAsInsert` static method.
*  **layoutNodes.ts/stateVariables.ts:** The `updateNode/updateVar` methods exported by their store-like objects have been renamed to `updateData` to support better refactoring. Possible future goal is to remove the need for passing the store's subscription value back into these mutation methods
