### PR TITLE
Dev/full node list

### DIFF
--- a/src/lib/classes/layoutNodes.ts
+++ b/src/lib/classes/layoutNodes.ts
@@ -152,7 +152,8 @@ export const layoutNodes = {
     },
 
     delete: (nodes: LayoutNodeProxy[], node: LayoutNodeProxy) => {
-        set(nodes.filter(n => n.id !== node.id))
+        nodes.splice(nodes.indexOf(node), 1)
+        set(nodes)
         node.deleteFromDB()
         if (node.parent_node_id) {
             const parent = nodes.filter(n => n.id === node.parent_node_id)[0]

--- a/src/lib/classes/stateVariables.ts
+++ b/src/lib/classes/stateVariables.ts
@@ -91,7 +91,8 @@ export const stateVariables = {
         varStore.set(vars)
     },
 
-    delete: (vars: StateVariableProxy[], id: number) => {
-        varStore.set(vars.filter(n => n.id !== id))
+    delete: (vars: StateVariableProxy[], stateVariable: StateVariableProxy) => {
+        vars.splice(vars.indexOf(stateVariable), 1)
+        varStore.set(vars)
     }
 }

--- a/src/lib/components/edit/proxyInput.svelte
+++ b/src/lib/components/edit/proxyInput.svelte
@@ -31,7 +31,7 @@
 
     const endEditing = () => {
         editing = false
-        proxy.setColumn(attrName, fieldValue)
+        proxy.setColumn(attrName, fieldValue)   // TODO: ensure string "" not passed to numbers
     }
 
     const onkey = (e: KeyboardEvent) => {

--- a/src/lib/components/fullNodeList.svelte
+++ b/src/lib/components/fullNodeList.svelte
@@ -1,26 +1,62 @@
 <script lang="ts">
-    import { layoutNodes } from "$lib/classes/layoutNodes"
+    import { LayoutNodeProxy, layoutNodes } from "$lib/classes/layoutNodes"
     import { activeNodeID } from "$lib/stores/editor"
 
     import { getModalStore } from '@skeletonlabs/skeleton'
     const modalStore = getModalStore()
 
+    export let root: boolean = true
+    export let children: LayoutNodeProxy[] = []
+
+    const close = () => modalStore.close()
 </script>
 
-<div id="unsaved-panel" 
-class="variant-glass-primary rounded px-4 pb-2 text-white flex flex-col">
+{#if root}
+    <div id="full-nodes-panel" 
+    class="bg-primary-600 rounded px-4 pb-2 text-white flex flex-col">
 
-    <h1 class="h3 mb-2">Layout Nodes</h1>
-    {#each $layoutNodes.filter(n => !n.parent_node_id) as node}
-        <button 
-            class="btn btn-sm mb-1 variant-ghost-primary"
-            on:dblclick={() => modalStore.close()} 
-            on:click={() => activeNodeID.set(node.id)}>
+        <h1 class="h3 mb-2">Layout Nodes</h1>
+
+        {#each $layoutNodes.filter(n => !n.parent_node_id) as node}
+            <button class="btn-style" on:dblclick={close}  on:click={() => activeNodeID.set(node.id)}>
+                {node.key}
+                {#if node.client}
+                <span class="pl-2 italic">(new)</span>
+                {/if}
+            </button>
+            
+            {#if node.children.length}
+                <div class="container">
+                    <svelte:self root={false} children={node.children}/>
+                </div>
+            {/if}         
+        {/each}
+    </div>
+{:else}
+    {#each children as node}
+        <button class="btn-style" on:dblclick={close}  on:click={() => activeNodeID.set(node.id)}>
             {node.key}
             {#if node.client}
-                <span class="pl-2 italic">(new)</span>
+            <span class="pl-2 italic">(new)</span>
             {/if}
         </button>
         
+        {#if node.children.length}
+            <div class="container">
+                <svelte:self children={node.children} root={false} />
+            </div>
+        {/if}
     {/each}
-</div>
+{/if}
+
+<style lang="postcss">
+    :global(.btn-style) {
+        @apply btn btn-sm mb-1 variant-ghost-primary
+    }
+
+    .container {
+        @apply border-2 rounded p-1 mb-4 mt-0 
+            border-primary-500 bg-primary-600 flex flex-col ml-4
+            border-t-0 border-r-0
+    }
+</style>

--- a/src/lib/components/fullNodeList.svelte
+++ b/src/lib/components/fullNodeList.svelte
@@ -1,62 +1,15 @@
 <script lang="ts">
-    import { LayoutNodeProxy, layoutNodes } from "$lib/classes/layoutNodes"
-    import { activeNodeID } from "$lib/stores/editor"
-
-    import { getModalStore } from '@skeletonlabs/skeleton'
-    const modalStore = getModalStore()
-
-    export let root: boolean = true
-    export let children: LayoutNodeProxy[] = []
-
-    const close = () => modalStore.close()
+    import { layoutNodes } from "$lib/classes/layoutNodes"
+	import SelectProxyButton from "./selectProxyButton.svelte";
 </script>
 
-{#if root}
-    <div id="full-nodes-panel" 
+<div id="full-nodes-panel" 
     class="bg-primary-600 rounded px-4 pb-2 text-white flex flex-col">
 
-        <h1 class="h3 mb-2">Layout Nodes</h1>
+    <h1 class="h3 mb-2">Layout Nodes</h1>
 
-        {#each $layoutNodes.filter(n => !n.parent_node_id) as node}
-            <button class="btn-style" on:dblclick={close}  on:click={() => activeNodeID.set(node.id)}>
-                {node.key}
-                {#if node.client}
-                <span class="pl-2 italic">(new)</span>
-                {/if}
-            </button>
-            
-            {#if node.children.length}
-                <div class="container">
-                    <svelte:self root={false} children={node.children}/>
-                </div>
-            {/if}         
-        {/each}
-    </div>
-{:else}
-    {#each children as node}
-        <button class="btn-style" on:dblclick={close}  on:click={() => activeNodeID.set(node.id)}>
-            {node.key}
-            {#if node.client}
-            <span class="pl-2 italic">(new)</span>
-            {/if}
-        </button>
-        
-        {#if node.children.length}
-            <div class="container">
-                <svelte:self children={node.children} root={false} />
-            </div>
-        {/if}
+    {#each $layoutNodes.filter(n => !n.parent_node_id) as node}
+        <SelectProxyButton proxy={node} tree={true}/>
     {/each}
-{/if}
+</div>
 
-<style lang="postcss">
-    :global(.btn-style) {
-        @apply btn btn-sm mb-1 variant-ghost-primary
-    }
-
-    .container {
-        @apply border-2 rounded p-1 mb-4 mt-0 
-            border-primary-500 bg-primary-600 flex flex-col ml-4
-            border-t-0 border-r-0
-    }
-</style>

--- a/src/lib/components/fullNodeList.svelte
+++ b/src/lib/components/fullNodeList.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+    import { layoutNodes } from "$lib/classes/layoutNodes"
+    import { activeNodeID } from "$lib/stores/editor"
+
+    import { getModalStore } from '@skeletonlabs/skeleton'
+    const modalStore = getModalStore()
+
+</script>
+
+<div id="unsaved-panel" 
+class="variant-glass-primary rounded px-4 pb-2 text-white flex flex-col">
+
+    <h1 class="h3 mb-2">Layout Nodes</h1>
+    {#each $layoutNodes.filter(n => !n.parent_node_id) as node}
+        <button 
+            class="btn btn-sm mb-1 variant-ghost-primary"
+            on:dblclick={() => modalStore.close()} 
+            on:click={() => activeNodeID.set(node.id)}>
+            {node.key}
+            {#if node.client}
+                <span class="pl-2 italic">(new)</span>
+            {/if}
+        </button>
+        
+    {/each}
+</div>

--- a/src/lib/components/layoutNode.svelte
+++ b/src/lib/components/layoutNode.svelte
@@ -2,7 +2,7 @@
     import type { StateVarValue } from '$lib/classes/dbProxy';
     import type { LayoutNodeProxy } from '$lib/classes/layoutNodes'
     import { stateVariables } from '$lib/classes/stateVariables'
-    import { activeNodeID, ctxMenu, scalePercent, type CtxMenu, type CtxMenuItem } from '$lib/stores/editor'
+    import { activeProxyID, ctxMenu, scalePercent, type CtxMenu, type CtxMenuItem } from '$lib/stores/editor'
     import { page } from '$app/stores'
     
     import { createEventDispatcher } from 'svelte'
@@ -35,7 +35,7 @@
 
     function isClicked(e: MouseEvent) {
         if (edit) {
-            activeNodeID.set(node.id)
+            activeProxyID.set(node.id)
             startMovement()
         }
 	}
@@ -70,7 +70,7 @@
         if (node.parent_node_id) {
             menu.push(
                 {key: 'Select Parent',
-                    action: () => activeNodeID.set(node.parent_node_id)
+                    action: () => activeProxyID.set(node.parent_node_id)
                 })
         }
 
@@ -103,7 +103,7 @@
     class="{node.classes} layout-node
         select-none cursor-pointer"
     class:absolute={!child}
-    class:layout-node-active={$activeNodeID === node.id}
+    class:layout-node-active={$activeProxyID === node.id}
     class:layout-node-edit={edit}
 >
     {#if content}

--- a/src/lib/components/layoutNode.svelte
+++ b/src/lib/components/layoutNode.svelte
@@ -98,6 +98,7 @@
     style:width={node.width ? `${node.width}px` : null}
     style:height={node.height ? `${node.height}px` : null}
     style:background-image={node.image ? `url(${imgURL})` : null}
+    style:display={!display ? 'none' : null}
 
     class="{node.classes} layout-node
         select-none cursor-pointer"

--- a/src/lib/components/menu/contextMenu.svelte
+++ b/src/lib/components/menu/contextMenu.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-    import { ctxMenu, activeNodeID, type CtxMenuItem, type CtxMenu } from "$lib/stores/editor"
+    import { ctxMenu, activeProxyID, type CtxMenuItem, type CtxMenu } from "$lib/stores/editor"
     import { LayoutNodeProxy, layoutNodes } from "$lib/classes/layoutNodes"
     
     let activeNode: LayoutNodeProxy | null 
-    $: activeNode = layoutNodes.getNodeByID($layoutNodes, $activeNodeID)
+    $: activeNode = layoutNodes.getNodeByID($layoutNodes, $activeProxyID)
 
     const handleClick = (e: MouseEvent, item: CtxMenuItem) => {
         if (item.disabled) {

--- a/src/lib/components/selectProxyButton.svelte
+++ b/src/lib/components/selectProxyButton.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+    import { LayoutNodeProxy } from "$lib/classes/layoutNodes"
+	import type { StateVariableProxy } from "$lib/classes/stateVariables";
+    import { activeProxyID } from "$lib/stores/editor"
+
+    import { getModalStore } from '@skeletonlabs/skeleton'
+    const modalStore = getModalStore()
+
+    export let proxy: LayoutNodeProxy | StateVariableProxy
+    export let tree: boolean = false
+
+    let children: LayoutNodeProxy[] = []
+    if (proxy instanceof LayoutNodeProxy) children = proxy.children
+</script>
+
+
+<button class="btn-style" 
+    on:dblclick={() => modalStore.close()}  
+    on:click={() => activeProxyID.set(proxy.id)}>
+
+    {proxy.key}
+    {#if proxy.client}
+        <span class="pl-2 italic">(new)</span>
+    {/if}
+</button>
+
+{#if children && children.length && tree}
+    <div class="container">
+        {#each children as child}
+            <svelte:self proxy={child} tree={true}/>
+        {/each}
+    </div>
+{/if}
+
+<style lang="postcss">
+    :global(.btn-style) {
+        @apply btn btn-sm mb-1 variant-ghost-primary
+    }
+
+    .container {
+        @apply border-2 rounded p-1 mb-4 mt-0 
+            border-primary-500 bg-primary-600 flex flex-col ml-4
+            border-t-0 border-r-0
+    }
+</style>

--- a/src/lib/components/unsavedPanel.svelte
+++ b/src/lib/components/unsavedPanel.svelte
@@ -1,8 +1,7 @@
 <script lang='ts'>
     import type { LayoutNodeProxy } from "$lib/classes/layoutNodes"
 	import type { StateVariableProxy } from "$lib/classes/stateVariables"
-    import { createEventDispatcher } from "svelte"
-    const dispatch = createEventDispatcher()
+	import SelectProxyButton from "./selectProxyButton.svelte";
 
     export let proxies: LayoutNodeProxy[] | StateVariableProxy[]
     export let header: string = "Unsaved:"
@@ -28,14 +27,7 @@
 
         <h1 class="h3 mb-2">{header}</h1>
         {#each proxies as proxy}
-            <button 
-                class="btn btn-sm mb-1 variant-ghost-primary" 
-                on:click={() => dispatch('clickProxy', proxy)}>
-                {proxy.key} 
-                {#if proxy.client}
-                    <span class="pl-2 italic">(new)</span>
-                {/if}
-            </button>
+            <SelectProxyButton proxy={proxy} />
         {/each}
 
         <div class="flex justify-around mt-2">

--- a/src/lib/stores/editor.ts
+++ b/src/lib/stores/editor.ts
@@ -3,7 +3,7 @@ import { localStorageStore } from '@skeletonlabs/skeleton'
 import { get } from "svelte/store"
 
 
-export const activeNodeID = writable<number|null>(null)
+export const activeProxyID = writable<number|null>(null)
 export const activeVarId = writable<number|null>(null)
 export const scalePercent: Writable<number> = localStorageStore('scalePercent', 100)
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,13 +1,19 @@
 <script lang='ts'>
 	import '../app.postcss'
 	import { Modal } from '@skeletonlabs/skeleton'
-	// import type { ModalComponent } from '@skeletonlabs/skeleton'
+	import type { ModalComponent } from '@skeletonlabs/skeleton'
 	import { initializeStores } from '@skeletonlabs/skeleton'
 	initializeStores()
+
+	import FullNodeList from '$lib/components/fullNodeList.svelte'
+
+	const components: Record<string, ModalComponent> = {
+		fullNodeList: {ref: FullNodeList},
+	}
 
 
 </script>
 
-<Modal />
+<Modal {components}/>
 
 <slot />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,6 +14,9 @@
 
 </script>
 
-<Modal {components} background="bg-primary-600" regionBody="text-white" regionHeader="text-white text-2xl font-bold"/>
+<Modal {components} background="bg-primary-600" 
+	regionBackdrop="variant-soft-secondary"
+	regionBody="text-white" 
+	regionHeader="text-white text-2xl font-bold"/>
 
 <slot />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,6 +14,6 @@
 
 </script>
 
-<Modal {components}/>
+<Modal {components} background="bg-primary-600" regionBody="text-white" regionHeader="text-white text-2xl font-bold"/>
 
 <slot />

--- a/src/routes/stream/[layout]/[[edit]]/+layout.svelte
+++ b/src/routes/stream/[layout]/[[edit]]/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { layoutNodes, type LayoutNodeUpdate } from '$lib/classes/layoutNodes.js'
     import { stateVariables, type StateVariableUpdate } from '$lib/classes/stateVariables.js'
-    import { activeNodeID } from '$lib/stores/editor'
+    import { activeProxyID } from '$lib/stores/editor'
     import { supabase } from '$lib/supabaseClient.js'
 	import { wheel } from '$lib/stores/editor'
 
@@ -38,7 +38,7 @@
     <div id='scale-bg'
         on:contextmenu|preventDefault
         on:wheel|preventDefault={wheel} 
-        on:mousedown={() => activeNodeID.set(null)}/>
+        on:mousedown={() => activeProxyID.set(null)}/>
 {/if}
 
 <slot />

--- a/src/routes/stream/[layout]/[[edit]]/+page.svelte
+++ b/src/routes/stream/[layout]/[[edit]]/+page.svelte
@@ -2,6 +2,8 @@
     import { userMeta } from '$lib/supabaseClient.js'
     import { getModalStore } from '@skeletonlabs/skeleton'
     const modalStore = getModalStore()
+    let modalOpen: boolean
+    $: modalOpen = Boolean($modalStore.length)
 
     import { page } from "$app/stores"
     import { activeNodeID, ctxMenu, scalePercent, type CtxMenu } from "$lib/stores/editor.js"
@@ -21,9 +23,14 @@
 
     let activeNode: LayoutNodeProxy|null
     $: activeNode = layoutNodes.getNodeByID($layoutNodes, $activeNodeID)
+    
     let rootNodes: LayoutNodeProxy[], unsavedNodes: LayoutNodeProxy[]
     $: rootNodes = $layoutNodes.filter(n => !n.parent_node_id)
     $: unsavedNodes = $layoutNodes.filter(n => n.unsaved)
+
+    const openNodeList = () => {
+        modalStore.trigger({type: 'component', component: 'fullNodeList'})
+    }
 
     const unselectNode = () => {
         if (edit) activeNodeID.set(null)
@@ -37,8 +44,8 @@
             value: 'new_node',
             valueAttr: { type: 'text', minlength: 1, required: true },
 
-            response: (r: string|false) => {
-                if (r === false) return
+            response: (r: string) => {
+                if (!r) return
                 if (!$userMeta.uid) throw Error("No User ID found in current userMeta")
 
                 layoutNodes.add($layoutNodes, r, $userMeta.uid, $page.data.layoutData.id)
@@ -68,16 +75,15 @@
             disabled: !unsavedNodes.length, 
             action: () => unsavedNodes.forEach(n => n.resetChanges())
         },
-        {key: "Add New Node",
-            action: () => addNode()
-        }
+        {key: "Add New Node", action: addNode},
+        {key: "Open Node List", action: openNodeList}
     ])
 
 </script>
-
 <svelte:window 
     on:click={ctxMenu.close} 
-    on:contextmenu|preventDefault={(e) => ctxMenu.open(e, getMenu())}/>
+    on:contextmenu|preventDefault={(e) => {if (!modalOpen) ctxMenu.open(e, getMenu())}}
+/>
 <ContextMenu />
 
 <!-- 'Edit Layout' panel for switching to edit mode -->
@@ -127,6 +133,15 @@
     <UnsavedPanel header="Unsaved Layout Nodes:"
         on:clickProxy={({detail}) => activeNodeID.set(detail.id)}
         proxies={unsavedNodes}/>
+    
+    <div id="open-node-list-panel" 
+        class="variant-glass-primary rounded p-4 text-white m-4">
+        
+        <button on:click={openNodeList}
+            class="btn btn-sm mb-1 variant-ghost-primary">
+            Open Node List
+        </button>
+    </div>
 {/if}
 
 <style lang="postcss">
@@ -134,6 +149,7 @@
         z-index: 2;
         opacity: 0;
         position: absolute;
+        @apply mt-2;
     }
     #open-editor-panel:hover {
         opacity: 1;
@@ -152,5 +168,16 @@
 
     #active-node-panel {
         @apply absolute top-0 right-0 md:mr-20 sm:mr-2
+    }
+
+    #open-node-list-panel {
+        position: absolute;
+        z-index: 2;
+        right: 100px;
+        bottom: 0;
+        opacity: 0;
+    }
+    #open-node-list-panel:hover {
+        opacity: 1
     }
 </style>

--- a/src/routes/stream/[layout]/[[edit]]/+page.svelte
+++ b/src/routes/stream/[layout]/[[edit]]/+page.svelte
@@ -6,7 +6,7 @@
     $: modalOpen = Boolean($modalStore.length)
 
     import { page } from "$app/stores"
-    import { activeNodeID, ctxMenu, scalePercent, type CtxMenu } from "$lib/stores/editor.js"
+    import { activeProxyID, ctxMenu, scalePercent, type CtxMenu } from "$lib/stores/editor.js"
     import { layoutNodes, LayoutNodeProxy } from "$lib/classes/layoutNodes.js"
     import { wheel } from "$lib/stores/editor.js"
 
@@ -22,7 +22,7 @@
     $: edit = data.edit
 
     let activeNode: LayoutNodeProxy|null
-    $: activeNode = layoutNodes.getNodeByID($layoutNodes, $activeNodeID)
+    $: activeNode = layoutNodes.getNodeByID($layoutNodes, $activeProxyID)
     
     let rootNodes: LayoutNodeProxy[], unsavedNodes: LayoutNodeProxy[]
     $: rootNodes = $layoutNodes.filter(n => !n.parent_node_id)
@@ -33,7 +33,7 @@
     }
 
     const unselectNode = () => {
-        if (edit) activeNodeID.set(null)
+        if (edit) activeProxyID.set(null)
     }
 
     const addNode = () => {
@@ -131,7 +131,7 @@
     <ScalePanel />
 
     <UnsavedPanel header="Unsaved Layout Nodes:"
-        on:clickProxy={({detail}) => activeNodeID.set(detail.id)}
+        on:clickProxy={({detail}) => activeProxyID.set(detail.id)}
         proxies={unsavedNodes}/>
     
     <div id="open-node-list-panel" 


### PR DESCRIPTION
Adds new modal component **fullNodesList.svelte** which displays tree structure of all nodes. Clicking a node name selects it as the active node using the new **selectProxyButton.svelte** component.

**INTERNAL**: The `activeNodeID` store has been renamed to `activeProxyID` to reflect more extensible usage.

* **routes/+layout.svelte:** The `fullNodeList` component added to modal component registry and the modal component itself now has styles applied to be more consistent.

**Piggybacks:**
* **layoutNodes.ts/stateVariables.ts:** fixed mutation bug when deleting nodes
* **layoutNode.svelte:** reverts a bug introduced in earlier merge that switched to style directives but left off the inline "display: none" style for conditional nodes.

**TODO**
* **proxyInput.svelte:** Fix bug where numeric inputs can get saved as "", prefer null.