### PR TITLE
Dev/set sibling order

### DIFF
--- a/src/lib/classes/dbProxy.ts
+++ b/src/lib/classes/dbProxy.ts
@@ -31,8 +31,8 @@ export class ProxyDBRow<T extends DatabaseTableName> {
         this.client = client
     }
 
-    get id(): number|null {
-        return this.data.id ?? null
+    get id(): number {
+        return this.data.id
     }
 
     get unsaved(): boolean {
@@ -112,7 +112,16 @@ export class ProxyDBRow<T extends DatabaseTableName> {
         }
     }
 
-    saveChangesToProxy() {
+    saveChangesToProxy(update:DatabaseUpdate<'layout_nodes'>|null=null) {
+        if (update) {
+            Object.assign(this.data, update)
+           
+            Object.keys((k: keyof DatabaseUpdate<'layout_nodes'>) => { 
+                    // @ts-ignore
+                    delete this.changes[k] 
+                }
+            )
+        }
         Object.assign(this.data, this.changes)
         this.changes = {}
         this.broadcast()

--- a/src/lib/classes/layoutNodes.ts
+++ b/src/lib/classes/layoutNodes.ts
@@ -137,5 +137,14 @@ export const layoutNodes = {
         nodes.splice(nodes.indexOf(node), 1)
         set(nodes)
         node.deleteFromDB()
+    },
+
+    getChildren: (nodes: LayoutNodeProxy[], node:LayoutNodeProxy): LayoutNodeProxy[] => {
+        return nodes.filter(n => n.parent_node_id === node.id).sort((a, b) => {
+            const {sa, sb} = {sa: a.sibling_order ?? 0, sb: b.sibling_order ?? 0}
+            if (sa > sb) return 1
+            if (sb > sa) return -1
+            return 0
+        })
     }
 }

--- a/src/lib/classes/layoutNodes.ts
+++ b/src/lib/classes/layoutNodes.ts
@@ -140,7 +140,6 @@ export const layoutNodes = {
     },
 
     getChildren: (nodes: LayoutNodeProxy[], node:LayoutNodeProxy): LayoutNodeProxy[] => {
-        debugger
         return nodes.filter(n => n.parent_node_id === node.id).sort((a, b) => {
             const {sa, sb} = {sa: a.sibling_order ?? 0, sb: b.sibling_order ?? 0}
             if (sa > sb) return 1

--- a/src/lib/classes/layoutNodes.ts
+++ b/src/lib/classes/layoutNodes.ts
@@ -140,6 +140,7 @@ export const layoutNodes = {
     },
 
     getChildren: (nodes: LayoutNodeProxy[], node:LayoutNodeProxy): LayoutNodeProxy[] => {
+        debugger
         return nodes.filter(n => n.parent_node_id === node.id).sort((a, b) => {
             const {sa, sb} = {sa: a.sibling_order ?? 0, sb: b.sibling_order ?? 0}
             if (sa > sb) return 1

--- a/src/lib/classes/stateVariables.ts
+++ b/src/lib/classes/stateVariables.ts
@@ -68,13 +68,6 @@ function getVarByKey(vars: StateVariableProxy[], key: string): StateVarValue {
     return stateVariable
 }
 
-function getVarStore(id: number|null): Readable<StateVarValue> {
-    if (id) { return derived(varStore, (vars) => {
-        return getVarByID(vars, id)
-    })
-    } else return writable('')
-}
-
 export const stateVariables = {
     subscribe: varStore.subscribe, 
     set: varStore.set, 
@@ -92,10 +85,10 @@ export const stateVariables = {
         )
     },
 
-    getVarByID, getVarByKey, getVarStore,
+    getVarByID, getVarByKey,
 
     add: (vars: StateVariableProxy[], key: string, user_id: string, value: string) => {
-        const stateVar = StateVariableProxy.getAsInsert(key, user_id, value, () => varStore.set(vars))
+        const stateVar = StateVariableProxy.getAsInsert({key, user_id, value}, () => varStore.set(vars))
         vars.push(stateVar)
         varStore.set(vars)
     },

--- a/src/lib/components/edit/editNodePanel.svelte
+++ b/src/lib/components/edit/editNodePanel.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import type { ProxyAttrs } from "$lib/classes/dbProxy"
-	import type { LayoutNodeProxy } from "$lib/classes/layoutNodes"
+	import { type LayoutNodeProxy, layoutNodes } from "$lib/classes/layoutNodes"
 	import EditProxyPanel from "./editProxyPanel.svelte"
-    import { setParentID, unsetParentID } from "$lib/menuActions"
+    import { orderChildNodes, setParentID, unsetParentID } from "$lib/menuActions"
     import { getModalStore } from "@skeletonlabs/skeleton"
     const modalStore = getModalStore()
 
@@ -16,6 +16,9 @@
         ['width', 'number'],
         ['height', 'number'],
     ]
+
+    let childNodes: LayoutNodeProxy[]
+    $: childNodes = $layoutNodes.filter((n) => n.parent_node_id === node.id)
 </script>
 
 <EditProxyPanel proxy={node} {attrs}/>
@@ -27,6 +30,11 @@
             <button on:click={() => unsetParentID(node)}>Unset Parent ID</button>
         {/if}
     </div>
+    {#if childNodes.length}
+    <div>
+        <button on:click={() => orderChildNodes(childNodes, modalStore)}>Order Child Nodes</button>
+    </div>
+    {/if}
     <div>
         <button>Set Variable ID</button>
         {#if node.variable_id}

--- a/src/lib/components/edit/editNodePanel.svelte
+++ b/src/lib/components/edit/editNodePanel.svelte
@@ -15,10 +15,11 @@
         'classes',
         ['width', 'number'],
         ['height', 'number'],
+        ["sibling_order", "number"]
     ]
 
     let childNodes: LayoutNodeProxy[]
-    $: childNodes = $layoutNodes.filter((n) => n.parent_node_id === node.id)
+    $: childNodes = layoutNodes.getChildren($layoutNodes, node)
 </script>
 
 <EditProxyPanel proxy={node} {attrs}/>

--- a/src/lib/components/edit/editNodePanel.svelte
+++ b/src/lib/components/edit/editNodePanel.svelte
@@ -20,20 +20,40 @@
 
 <EditProxyPanel proxy={node} {attrs}/>
 
-<div class="variant-glass-primary m-4 rounded p-3 text-white flex flex-col">
+<div class="variant-glass-primary m-4 rounded p-3 text-white flex flex-col actions-panel">
     <div>
+        <button on:click={() => setParentID(node, modalStore)}>Set Parent ID</button>
         {#if node.parent_node_id}
             <button on:click={() => unsetParentID(node)}>Unset Parent ID</button>
         {/if}
-        <button on:click={() => setParentID(node, modalStore)}>Set Parent ID</button>
     </div>
-    <button>Set Variable ID</button>
-    <button>Set Conditional Boolean ID</button>
+    <div>
+        <button>Set Variable ID</button>
+        {#if node.variable_id}
+            <button >Unset Variable ID</button>
+        {/if}
+    </div>
+    <div>
+        <button>Set Boolean ID</button>
+        {#if node.boolean_id}
+            <button >Unset Boolean ID</button>
+        {/if}
+    </div>
+    <div>
+        <button>Set Image</button>
+        {#if node.image}
+            <button >Unset Image</button>
+        {/if}
+    </div>
 </div>
 
 <!-- svelte-ignore css-unused-selector -->
 <style lang='postcss'>
     button {
-        @apply mb-1 btn variant-filled-primary
+        @apply mb-1 btn variant-filled-primary w-[100%]
+    }
+
+    .actions-panel div {
+        @apply flex justify-between
     }
 </style>

--- a/src/lib/components/edit/editNodePanel.svelte
+++ b/src/lib/components/edit/editNodePanel.svelte
@@ -14,8 +14,7 @@
         ['left', 'number'],
         'classes',
         ['width', 'number'],
-        ['height', 'number'],
-        ["sibling_order", "number"]
+        ['height', 'number']
     ]
 
     let childNodes: LayoutNodeProxy[]
@@ -33,7 +32,7 @@
     </div>
     {#if childNodes.length}
     <div>
-        <button on:click={() => orderChildNodes(childNodes, modalStore)}>Order Child Nodes</button>
+        <button on:click={() => orderChildNodes(node, modalStore)}>Order Child Nodes</button>
     </div>
     {/if}
     <div>

--- a/src/lib/components/layoutNode.svelte
+++ b/src/lib/components/layoutNode.svelte
@@ -90,7 +90,7 @@
     }
 
     let childNodes: LayoutNodeProxy[]
-    $: childNodes = $layoutNodes.filter((n) => n.parent_node_id === node.id)
+    $: childNodes = layoutNodes.getChildren($layoutNodes, node)
 </script>
 
 <svelte:window on:mouseup={stopMovement} on:mousemove={move}  />

--- a/src/lib/components/layoutNode.svelte
+++ b/src/lib/components/layoutNode.svelte
@@ -25,7 +25,8 @@
     }
 
     // handle var values / interpolation
-    const varValue = stateVariables.getVarStore(node.variable_id)
+    let varText: string
+    $: varText = String(stateVariables.getVarByID($stateVariables, node.variable_id))
     let content: string
     $: content = node.interpolate(
         (key: string) => stateVariables.getVarByKey($stateVariables, key)
@@ -124,7 +125,7 @@
 
     {#if node.variable_id}
         <span class="layout-node-var">
-            {$varValue}
+            {varText}
         </span>
     {/if}
 

--- a/src/lib/components/orderNodesPanel.svelte
+++ b/src/lib/components/orderNodesPanel.svelte
@@ -1,10 +1,48 @@
 <script lang="ts">
-	import type { LayoutNodeProxy } from "$lib/classes/layoutNodes"
+	import { layoutNodes, type LayoutNodeProxy } from "$lib/classes/layoutNodes"
     import { getModalStore } from '@skeletonlabs/skeleton'
+	import { onMount } from "svelte";
+	import { fade, slide } from "svelte/transition";
     const modalStore = getModalStore()
 
+    let parentNode: LayoutNodeProxy|null
+    $: parentNode = $modalStore[0]?.meta?.parentNode ?? null
+
     let childNodes: LayoutNodeProxy[] = []
-    $: childNodes = $modalStore[0]?.meta?.childNodes ?? []
+    $: {
+        if (parentNode) childNodes = layoutNodes.getChildren($layoutNodes, parentNode)
+    }
+
+    const normalize = (nodes: LayoutNodeProxy[]) => {
+        for (let i = 0; i < nodes.length; i++) {
+            childNodes[i].saveChangesToProxy({"sibling_order": i + 1})
+        }
+    }
+    onMount(() => {
+        normalize(childNodes)
+    })
+
+    const moveUp = (node: LayoutNodeProxy) => {
+        let index = childNodes.indexOf(node)
+        if (index === 0) return
+
+        let prev = childNodes[index - 1]
+        let higher = node.sibling_order
+        let lower = prev.sibling_order
+        node.setColumn("sibling_order", lower)
+        prev.setColumn("sibling_order", higher)
+    }
+
+    const moveDown = (node: LayoutNodeProxy) => {
+        let index = childNodes.indexOf(node)
+        if (index === childNodes.length - 1) return
+
+        let next = childNodes[index + 1]
+        let higher = next.sibling_order
+        let lower = node.sibling_order
+        node.setColumn("sibling_order", higher)
+        next.setColumn("sibling_order", lower)
+    }
 </script>
 
 
@@ -12,6 +50,13 @@
     <h1 class="h3 mb-2">Order Child Nodes</h1>
 
     {#each childNodes as node}
-        <div>{node.key}</div>
+        <div class="bg-primary-500 rounded-full p-2 mb-2 flex justify-between items-center">
+            {node.key}
+
+            <div class="ml-2 btn-group bg-primary-600">
+                <button on:click={() => moveDown(node)}>+</button>
+                <button on:click={() => moveUp(node)}>-</button>
+            </div>
+        </div>
     {/each}
 </div>

--- a/src/lib/components/orderNodesPanel.svelte
+++ b/src/lib/components/orderNodesPanel.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import type { LayoutNodeProxy } from "$lib/classes/layoutNodes"
+    import { getModalStore } from '@skeletonlabs/skeleton'
+    const modalStore = getModalStore()
+
+    let childNodes: LayoutNodeProxy[] = []
+    $: childNodes = $modalStore[0]?.meta?.childNodes ?? []
+</script>
+
+
+<div class="variant-glass-primary rounded px-4 pb-2 text-white flex flex-col">
+    <h1 class="h3 mb-2">Order Child Nodes</h1>
+
+    {#each childNodes as node}
+        <div>{node.key}</div>
+    {/each}
+</div>

--- a/src/lib/components/selectProxyButton.svelte
+++ b/src/lib/components/selectProxyButton.svelte
@@ -10,7 +10,7 @@
     export let disabled: Number[] = []
 
     let children: LayoutNodeProxy[] = []
-    if (proxy instanceof LayoutNodeProxy) children = $layoutNodes.filter((n) => n.parent_node_id === proxy.id)
+    if (proxy instanceof LayoutNodeProxy) children = layoutNodes.getChildren($layoutNodes, proxy)
 </script>
 
 

--- a/src/lib/menuActions.ts
+++ b/src/lib/menuActions.ts
@@ -21,12 +21,10 @@ export const unsetParentID = (node: LayoutNodeProxy) => {
     node.setColumn("parent_node_id", null)
 }
 
-export const orderChildNodes = (childNodes: LayoutNodeProxy[], modalStore: ModalStore) => {
+export const orderChildNodes = (parentNode: LayoutNodeProxy, modalStore: ModalStore) => {
     modalStore.trigger({
         type: 'component',
         component: 'orderChildNodes',
-        meta: {
-            childNodes
-        }
+        meta: {parentNode}
     })
 }

--- a/src/lib/menuActions.ts
+++ b/src/lib/menuActions.ts
@@ -20,3 +20,13 @@ export const setParentID = (node: LayoutNodeProxy, modalStore: ModalStore) => {
 export const unsetParentID = (node: LayoutNodeProxy) => {
     node.setColumn("parent_node_id", null)
 }
+
+export const orderChildNodes = (childNodes: LayoutNodeProxy[], modalStore: ModalStore) => {
+    modalStore.trigger({
+        type: 'component',
+        component: 'orderChildNodes',
+        meta: {
+            childNodes
+        }
+    })
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,9 +6,11 @@
 	initializeStores()
 
 	import FullNodeList from '$lib/components/fullNodeList.svelte'
+	import OrderNodesPanel from '$lib/components/orderNodesPanel.svelte'
 
 	const components: Record<string, ModalComponent> = {
 		fullNodeList: {ref: FullNodeList},
+		orderChildNodes: {ref: OrderNodesPanel}
 	}
 
 </script>


### PR DESCRIPTION
* **src/lib/classes/dbProxy.ts:** `saveChangesToProxy` now takes an optional DatabaseUpdate type argument so values can be updated directly without triggering the unsaved changes boolean.
* **src/lib/classes/layoutNodes.ts:** Now exports a `getChildren` method that properly sorts by sibling order.
* **src/lib/classes/stateVariables.ts:** `getVarStore` removed as it is no longer needed and was causing re-render errors in node lists.
* **src/lib/components/edit/editNodePanel.svelte:** Layout in place for full set of actions, including set and unset of variable ID, parent ID, boolean ID, and image source, as well as the "order child nodes" option.
* **src/lib/components/layoutNode.svelte:** Uses `getChildren` method to get properly ordered list of child nodes and also calls `getVarByID` to get main var value instead of derived store, due to rendering errors when the node order is mutated.

**NEW**
* **src/lib/components/orderNodesPanel.svelte:** Modal component that allows for swapping the order of child nodes. Reads the `parentNode` object from the meta value passed to the modal store and calls `layoutNodes.getChildren()` to properly order the child nodes. In addition to the actual moveUp and moveDown functions that allow for swapping the order, this component calls a `normalize` function when mounted that automatically adjusts the `sibling_order` values on each child node to form a sequential list starting from 1.

* **src/lib/components/selectProxyButton.svelte:** Also uses `getChildren` now.
* **src/lib/menuActions.ts:** exports the `orderChildNodes` function that is used to trigger the orderChildNodes modal.
* **src/routes/+layout.svelte:** Adds the orderChildNodes component to the modal registry.