### PR TITLE
Dev/upload images

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,4 +1,4 @@
-import { createClient, type AuthChangeEvent, type Session } from "@supabase/supabase-js";
+import { createClient, type AuthChangeEvent, type Session, type User } from "@supabase/supabase-js";
 import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL, PUBLIC_ADMIN_PASSWORD, PUBLIC_ADMIN_EMAIL } from "$env/static/public";
 import type { Database } from '$lib/types/supabase';
 import { writable, type Writable } from "svelte/store";
@@ -6,13 +6,19 @@ import { writable, type Writable } from "svelte/store";
 export const supabase = createClient<Database>(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY)
 
 // dev mode hack
-export const devLogin = () => {
+export const devLogin = async (): Promise<User> => {
     if (import.meta.env.DEV) {
-        supabase.auth.signInWithPassword({
+        const { data, error } = await supabase.auth.signInWithPassword({
             email: PUBLIC_ADMIN_EMAIL,
             password: PUBLIC_ADMIN_PASSWORD
         })
+        
+        if (error) throw new Error(error.message)
+
+        if (data.user === undefined) throw new Error('Dev login failed')
+        return data.user
     }
+    throw new Error('Auth not implemented yet')
 }
 
 export const userMeta: Writable<{uid?: string}> = writable({})

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang='ts'>
 	import '../app.postcss'
-	import { Modal } from '@skeletonlabs/skeleton'
+	import { Modal, Toast } from '@skeletonlabs/skeleton'
 	import type { ModalComponent } from '@skeletonlabs/skeleton'
 	import { initializeStores } from '@skeletonlabs/skeleton'
 	initializeStores()
@@ -22,5 +22,7 @@
 	regionBackdrop="variant-soft-secondary"
 	regionBody="text-white" 
 	regionHeader="text-white text-2xl font-bold"/>
+
+<Toast />
 
 <slot />

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -2,6 +2,7 @@ export const ssr = false
 
 export function load() {
     return {
+        // @ts-ignore
         inOBS: Boolean(window?.obsstudio)
     }
 }

--- a/src/routes/images/+layout.server.ts
+++ b/src/routes/images/+layout.server.ts
@@ -1,0 +1,30 @@
+import { error as routeError } from '@sveltejs/kit'
+import { devLogin, supabase } from "$lib/supabaseClient"
+import { PUBLIC_SUPABASE_URL } from '$env/static/public'
+
+const getImageData = async (user_id: string) => {
+    let { data, error } = await supabase.storage.from('user_images').list(user_id)
+
+    if (error) throw new Error(error.message)
+
+    return data ?? []
+}
+
+export async function load() {
+    try {
+        const user = await devLogin()
+
+        const imageData = await getImageData(user.id)
+
+        const imageBaseUrl = `${PUBLIC_SUPABASE_URL}/storage/v1/object/public/user_images/${user.id}/`
+
+        return {
+            imageData,
+            imageBaseUrl
+        }
+    }
+    
+     catch {
+        throw routeError(404, 'Layout not found')
+    }
+}

--- a/src/routes/images/+layout.svelte
+++ b/src/routes/images/+layout.svelte
@@ -1,0 +1,14 @@
+<div id='faux-bg' />
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<slot />
+
+<style>
+    #faux-bg {
+        background-color: #333;
+        position: absolute;
+        width: 100vw;
+        height: 100vh;
+        z-index: -100;
+    }
+</style>

--- a/src/routes/images/+page.svelte
+++ b/src/routes/images/+page.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	import { supabase, userMeta } from "$lib/supabaseClient"
+	import type { FileDropzoneEvents } from "@skeletonlabs/skeleton/dist/components/FileDropzone/FileDropzone.svelte";
+	import type { PageData } from "./$types"
+    import { getModalStore, getToastStore, FileDropzone } from '@skeletonlabs/skeleton'
+    const modalStore = getModalStore()
+    const toastStore = getToastStore()
+
+    export let data: PageData
+    let imageData = data.imageData
+    let images: string[] = imageData.map(i => i.name)
+
+    const getURI = (name: string): string => `${data.imageBaseUrl}${name}`
+
+    const deleteImage = async (name: string, i: number) => {
+        modalStore.trigger({
+            type: 'confirm',
+            title: `Delete ${name}?`,
+            body: 'Confirm you want to delete this image. This is not reversible!',
+            response: async (r: boolean) => {
+                if (!r) return
+                else {
+                    const file_name = `${$userMeta.uid}/${name}`
+                    const { error } = await supabase.storage.from('user_images')
+                        .remove([file_name])
+                    
+                    if (error) throw new Error(error.message)
+                    images.splice(i, 1)
+                    images = images
+                    toastStore.trigger({message: `${name} was deleted`})
+                }
+            }
+        })
+    }
+
+    let files: FileList
+    const onChange = async () => {
+        console.log(files)
+        if (files.length) {
+            const fileName = files[0].name
+            const { data, error } = await supabase.storage.from('user_images')
+                .upload(`${$userMeta.uid}/${fileName}`, files[0])
+            
+            if (error) throw new Error(error.message)
+
+            console.log(data)
+            images.push(fileName)
+            images = images
+            toastStore.trigger({message: `${fileName}`})
+        }
+
+    }
+</script>
+
+<div id="images-container" class="scroll-auto flex flex-col overflow-y-scroll py-4 px-10 h-[90vh]">
+    {#each images as image, i}
+    <div class="bg-primary-600 rounded p-2 mb-1 text-white">
+        <div class="flex items-center justify-between">
+            <span class="font-bold">{image}</span>
+
+            <button on:click={() => deleteImage(image, i)}
+                class="btn btn-sm variant-filled-primary">
+                delete
+            </button>
+        </div>
+        <img src={getURI(image)} alt={image} />
+    </div>
+    {/each}
+</div>
+
+<div id="file-dropzone">
+    <FileDropzone name="files" bind:files={files} on:change={onChange}/>
+</div>
+
+<style lang="postcss">
+    #images-container {
+        @apply m-4;
+        width: 500px;
+        z-index: 0;
+    }
+
+    #file-dropzone {
+        @apply m-4 absolute;
+        top: 0;
+        left: 550px;
+        width: 500px;
+    }
+</style>
+

--- a/src/routes/images/+page.svelte
+++ b/src/routes/images/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { supabase, userMeta } from "$lib/supabaseClient"
-	import type { FileDropzoneEvents } from "@skeletonlabs/skeleton/dist/components/FileDropzone/FileDropzone.svelte";
 	import type { PageData } from "./$types"
     import { getModalStore, getToastStore, FileDropzone } from '@skeletonlabs/skeleton'
     const modalStore = getModalStore()

--- a/src/routes/vars/+page.svelte
+++ b/src/routes/vars/+page.svelte
@@ -18,7 +18,7 @@
     {#each $stateVariables as sv}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <!-- svelte-ignore a11y-no-static-element-interactions -->
-        <div class="bg-primary-500 rounded-sm p-2 mb-1 text-white h4 flex justify-between">
+        <div class="bg-primary-600 rounded p-2 mb-1 text-white h4 flex justify-between">
             
             <span>{sv.key}: {sv.value}</span>
             


### PR DESCRIPTION
* **src/lib/supabaseClient.ts:** Dev Login now returns the user object to allow for future changes that will better support actual implementation of user auth. For now, login function throws error is the `meta.evn.DEV` value is not true.
* **src/routes/+layout.svelte:** Also initialized Skeleton's toastStore for toast messages.

* **src/routes/images/+layout.server.ts:** For now this server loader just awaits the built in `devLogin()` method, but this does allow it to use the user ID from the user object in other async methods. Other loaders should adopt this pattern as it will integrate better with the future proper user auth implementation.
* **src/routes/images/+page.svelte:** Page component simply implements Skeleton's File Dropzone component and also a list of loaded images with associated "delete" buttons. **FUTURE:** Subscription to the `storage.objects` table may eventually be implemented to allow for outside APIs / other programmatic file uploading actions to be reflected on the client side.

